### PR TITLE
Code speedup due to faster einsum replacement

### DIFF
--- a/simdkalman/primitives.py
+++ b/simdkalman/primitives.py
@@ -26,7 +26,7 @@ def ddot(A, B):
 
 def ddot_t_right(A, B):
     "Matrix multiplication over last 2 axes with right operand transposed"
-    return np.einsum('...ij,...kj->...ik', A, B, **_EINSUM_OPTS)
+    return np.matmul(A, np.swapaxes(B, -1, -2))
 
 def douter(a, b):
     "Outer product, last two axes"


### PR DESCRIPTION
I use your simdkalman in my AutoTS project, thanks for the work, it is excellent code.
While running the scalene profiler on my code base it identified a possible performance improvement and suggested a speedup. The credit for this really goes to GPT v4.

I've tested the speedup and it is faster and functionally identical for my use case. I haven't necessarily tested this on your entire code bases range of inputs and outputs so there may be some hidden catch that I am unaware of.

simple speed comparison:
```
%timeit np.einsum("...ij,...kj->...ik", A, B)
31 ms ± 967 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit np.matmul(A, np.swapaxes(B, -1, -2))
7.61 ms ± 328 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
it's hard to quantify the bigger picture but it looks like it makes the function about 10% faster overall, in my use case
