### PR TITLE
Update kalmanfilter.py for lower memory usage

### DIFF
--- a/simdkalman/kalmanfilter.py
+++ b/simdkalman/kalmanfilter.py
@@ -107,11 +107,14 @@ class Gaussian:
         self.mean = mean
         if cov is not None:
             self.cov = cov
+        else:
+            self.cov = None
 
     @staticmethod
     def empty(n_states, n_vars, n_measurements, cov=True):
         mean = np.empty((n_vars, n_measurements, n_states))
         if cov:
+            # for lower memory switch to ...n_states), dtype=np.float32)
             cov = np.empty((n_vars, n_measurements, n_states, n_states))
         else:
             cov = None
@@ -352,7 +355,7 @@ class KalmanFilter(object):
         initial_covariance = None,
         observations = True,
         states = True,
-        covariances = True,
+        covariances = False,
         verbose = False):
         """
         Smooth given data, which can be either
@@ -557,15 +560,15 @@ class KalmanFilter(object):
                 result.smoothed.states = empty_gaussian()
 
                 # lazy trick to keep last filtered = last smoothed
-                result.smoothed.states.mean = 1*filtered_states.mean
+                result.smoothed.states.mean = filtered_states.mean
                 if covariances:
-                    result.smoothed.states.cov = 1*filtered_states.cov
+                    result.smoothed.states.cov = filtered_states.cov
 
             if observations:
                 result.smoothed.observations = empty_gaussian(n_states=n_obs)
-                result.smoothed.observations.mean = 1*filtered_observations.mean
+                result.smoothed.observations.mean = filtered_observations.mean
                 if covariances:
-                    result.smoothed.observations.cov = 1*filtered_observations.cov
+                    result.smoothed.observations.cov = filtered_observations.cov
 
             if gains:
                 result.smoothed.gains = np.zeros((n_vars, n_measurements, n_states, n_states))


### PR DESCRIPTION
Hi again,
working with large matrices (2000 x 30000) I ran into some memory issues on computers with less RAM. I went looking for some quick fixes and found a few:

- The easiest change here is removing `1*matrix` operations that were resulting in an unnecessary copy. I think the original intention was just for clarity, and removing these saves a surprising amount of RAM. This change had no effect on predictions in my test.
- had to add a change to allow passing `covariances=False` to .smooth(). Code was written to expect self.cov=None but was never set to None. My guess is you've always been testing with covariance used.
- I set the new default for .smooth() to covariance = False. This reduced max memory for a sample from max: 6.678 GB to max: 4.325 GB and I don't see any need for the covariance here (unlike in predict where cov is useful). But you might disagree if you have some use for that.
- Added a comment about using float32 instead of float64 for the np.empty call. Unsurprisingly, this cuts memory use in half. However it comes with a small change in calculated values (by 4.8043524443673274e-08% in my case, so really really small). As a result I made this change in my personal version of the code but have not pushed it to master, just added a comment for anyone else who looks into this.

Overall in a test case this brings memory use from 17 GB down to 7 GB, (and down to 4 GB with float32 change) measured using scalene profiler.